### PR TITLE
Pooled redis management & id creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+import os
+
 # Plivo Auth ID and Auth Token
 PLIVO_AUTH_ID = ''
 PLIVO_AUTH_TOKEN = ''
@@ -25,3 +27,8 @@ ALLOW_INBOUND_DID = False
 
 # Expire a conference in 24 hours when this flag is enabled.
 EXPIRE_CONFERENCE = not ALLOW_INBOUND_DID
+
+# Redis config options
+REDIS_URL = os.getenv('REDISTOGO_URL', 'redis://localhost:6379')
+REDIS_MAX_CONNECTIONS = 10
+REDIS_TIMEOUT = 5  # in seconds - in the worst case, will add this much to response time

--- a/utils.py
+++ b/utils.py
@@ -1,24 +1,63 @@
-import os
-import time
 import base64
-import redis
 import config
+import contextlib
+import os
 import plivo
+import random
+import redis
+import urlparse
 
-def baseN(num,b,numerals="0123456789abcdefghijklmnopqrstuvwxyz"): 
-    return ((num == 0) and  "0" ) or (baseN(num // b, b).lstrip("0") + numerals[num % b])
 
-def tinyid(size=6):
-    id = '%s%s' % (
-            baseN(abs(hash(time.time())), 36), 
-            baseN(abs(hash(time.time())), 36))
-    return id[0:size]
+# Set up the redis pool, with some url parsing logic
+# See redis.client.StrictRedis.from_url for a reference
+#    (It would have been nice if py-redis exported from_url)
+def _make_redis_pool():
+    url = urlparse(config.REDIS_URL)
+    assert url.scheme == 'redis' or not url.scheme
+    try:
+        db = int(url.path.replace('/', ''))
+    except:
+        db = 0
+    return redis.BlockingConnectionPool(
+        max_connections = config.REDIS_MAX_CONNECTIONS,
+        timeout = config.REDIS_TIMEOUT,
+        host = url.hostname,
+        port = int(url.port or 6379),
+        db = db,
+        password = url.password,
+    )
+_pool = _make_redis_pool()
 
-def get_redis_connection():
-    redis_url = os.getenv('REDISTOGO_URL', 'redis://localhost:6379')
-    rd = redis.from_url(redis_url)
-    return rd
+            
+def make_id(size=6):
+    """Generate a base-36 encoded string of the specified size.
+    
+    The string is gaurunteed to be unique since the last time redis was
+    rebooted. This uses redis' INCR command for an atomic
+    get-and-increment on an ID key, to avoid race conditions. As such,
+    this function is fully thread and process safe. Avoid using this if
+    you don't need that gauruntee.
+    """
+    # NB: Do we want to use capital letters? More traditional for Base36
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    redis = get_redis_connection()
+    unique_val = redis.incr('ID_AUTO_INCR', 1)
+    rand = random.Random(unique_val)
+    return ''.join(random.choice(alphabet) for _ in range(size))
+
+
+@contextmanager
+def redis_client():
+    """Context manager that provides a redis client connection.
+    
+    This is thread-safe and process-safe. It may potentially block
+    for up to config.REDIS_TIMEOUT seconds, though (at which
+    point it will fail with an exception).
+    """
+    client = redis.StrictRedis(connection_pool=_pool)
+    yield
+    _pool.release(client)
+    
 
 def get_plivo_connection():
-    pl = plivo.RestAPI(config.PLIVO_AUTH_ID, config.PLIVO_AUTH_TOKEN)
-    return pl
+    return plivo.RestAPI(config.PLIVO_AUTH_ID, config.PLIVO_AUTH_TOKEN)

--- a/utils.py
+++ b/utils.py
@@ -40,8 +40,8 @@ def make_id(size=6):
     """
     # NB: Do we want to use capital letters? More traditional for Base36
     alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-    redis = get_redis_connection()
-    unique_val = redis.incr('ID_AUTO_INCR', 1)
+    with redis_client() as redis:
+        unique_val = redis.incr('ID_AUTO_INCR', 1)
     rand = random.Random(unique_val)
     return ''.join(random.choice(alphabet) for _ in range(size))
 
@@ -55,7 +55,7 @@ def redis_client():
     point it will fail with an exception).
     """
     client = redis.StrictRedis(connection_pool=_pool)
-    yield
+    yield client
     _pool.release(client)
     
 

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import base64
 import config
-import contextlib
+from contextlib import contextmanager
 import os
 import plivo
 import random


### PR DESCRIPTION
Hello,

In a late night bout of insomnia I saw your project on reddit, liked it, and thought I might contribute.

These changes use pooled redis connections to avoid scaling issues and potential resource leaks through unreleased connections or network threashing. Admittedly those cases would only show up under fairly heavy load, but the functionality exists, so why not?

I also replaced the tinyid function with a make_id function that stores an incremented value in redis. New ids are created by INCR'ing that value and using it as a seed for a random string in base36. I'm actually not super happy with that result, and might change it if I can think of a better scheme. Basically, what I'm trying to find is a way to go from integer -> string such that it isn't immediately obvious what the original integer was, but is still one-to-one. Anyway, using the INCR means there's no reason for a collision to EVER occur. But by using random I re-introduce that possibility. Hrm. I'll keep thinking on that one.
