### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Jinja2==2.7.2
 MarkupSafe==0.18
 Werkzeug==0.9.4
-distribute==0.6.27
+distribute
 gunicorn==18.0
 itsdangerous==0.23
 plivo==0.9.4


### PR DESCRIPTION
When "distribute" has a version number specified, the app fails to deploy to heroku (see https://github.com/plivo/voicechat/issues/7)
