### PR TITLE
removed wsgiref which causes heroku build to fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ itsdangerous==0.23
 plivo==0.9.4
 redis==2.9.0
 requests==2.2.0
-wsgiref==0.1.2
 yolk==0.4.3


### PR DESCRIPTION
I've removed wsgiref form the requirements, given it comes shipped in python 3. See https://stackoverflow.com/questions/31013976/django-1-8-deployment-error-on-heroku for more details.